### PR TITLE
Add Docker-based web service setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 8000
+
+# Start Gunicorn with Uvicorn workers
+CMD ["gunicorn", "app.main:app", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Init for app package

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root():
+    """Return a simple message indicating the API is running."""
+    return {"message": "LEXA API is running"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    command: gunicorn app.main:app -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,45 @@
+# Despliegue
+
+Este proyecto incluye un contenedor Docker con Gunicorn y Uvicorn para servir la aplicación FastAPI.
+
+## Construir y ejecutar localmente
+
+```bash
+docker-compose up --build
+```
+
+La API quedará disponible en `http://localhost:8000`.
+
+## Render
+
+1. Cree un nuevo servicio de "Web Service".
+2. Conecte el repositorio y configure el despliegue automático.
+3. Establezca el comando de inicio:
+   ```
+   gunicorn app.main:app -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
+   ```
+4. Configure la variable `PORT` en `8000` si es necesario.
+
+## Railway
+
+1. Importe el repositorio como nuevo proyecto.
+2. En la pestaña de servicio, defina el puerto `8000` y el comando de inicio como en Render.
+3. Railway construirá la imagen automáticamente con el `Dockerfile` incluido.
+
+## Fly.io
+
+1. Instale la CLI de Fly y ejecute `fly launch`.
+2. Acepte el `Dockerfile` existente y configure el puerto `8080` interno apuntando a `8000`.
+3. Despliegue con `fly deploy`.
+
+## Servidor propio
+
+1. Copie el repositorio al servidor.
+2. Construya la imagen:
+   ```bash
+   docker build -t lexa-app .
+   ```
+3. Ejecute el contenedor:
+   ```bash
+   docker run -d -p 8000:8000 lexa-app
+   ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+gunicorn


### PR DESCRIPTION
## Summary
- add minimal FastAPI app served with Gunicorn/Uvicorn
- add Dockerfile, docker-compose config, and requirements
- document deployment instructions for Render, Railway, Fly.io, and self-hosting

## Testing
- `docker compose up --build` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68960a1861448326922882852b01cc6e