### PR TITLE
test: add FastAPI endpoint tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,26 @@
+import pytest
+
+# Skip tests if FastAPI or API app is not available
+fastapi = pytest.importorskip("fastapi")
+try:
+    from src.api import app
+except Exception:
+    pytest.skip("FastAPI app not available", allow_module_level=True)
+
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+
+def test_generar_endpoint():
+    response = client.post("/generar", json={"prompt": "hola"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "resultado" in data or "result" in data
+
+
+def test_clasificar_endpoint():
+    response = client.post("/clasificar", json={"texto": "documento"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "categoria" in data or "classification" in data


### PR DESCRIPTION
## Summary
- add FastAPI TestClient tests for `/generar` and `/clasificar` endpoints

## Testing
- `pytest tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68960a16be988326ac4b5ef9ef9aba45