### PR TITLE
Add basic usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# LEXA
+
+## Instalación
+
+Instala las dependencias necesarias:
+
+```bash
+pip install fastapi uvicorn
+```
+
+## Ejecución del servidor
+
+Inicia el servidor de desarrollo:
+
+```bash
+uvicorn api.main:app --reload
+```
+
+## Verificación
+
+Después de iniciar el servidor, abre en tu navegador o consulta con `curl` la URL:
+
+```
+http://localhost:8000
+```
+
+Deberías recibir una respuesta del servicio.


### PR DESCRIPTION
## Summary
- document how to install dependencies with pip
- explain starting the development server via uvicorn
- show how to verify the API responds at localhost

## Testing
- `pip install fastapi uvicorn` (failed: Could not find a version that satisfies the requirement fastapi)
- `uvicorn api.main:app --reload` (failed: command not found)
- `curl -I http://localhost:8000` (failed: Could not connect to server)
- `pytest -q` (failed: 68 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68960a15d27883269bc7fdc853a09663