### PR TITLE
Add API configuration module

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,33 @@
+"""Configuration module for API relying on environment variables.
+
+Loads variables from a `.env` file at the repository root using python-dotenv
+and exposes constants for API keys and resource paths.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Resolve repository root directory
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+# Load variables from .env at the project root
+load_dotenv(ROOT_DIR / ".env")
+
+# API keys
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY", "")
+
+# Optional Google Sheets integration
+AV_SHEETS_CREDENTIALS = os.getenv("AV_SHEETS_CREDENTIALS", "")
+AV_SHEETS_ID = os.getenv("AV_SHEETS_ID", "")
+AV_SHEETS_NAME = os.getenv("AV_SHEETS_NAME", "")
+
+# Paths to PDF resources
+DEMANDAS_PATH = ROOT_DIR / os.getenv("DEMANDAS_PATH", "data/demandas_ejemplo")
+JURIS_PATH = ROOT_DIR / os.getenv("JURIS_PATH", "data/jurisprudencia")
+LEGAL_CORPUS_PATH = ROOT_DIR / os.getenv("LEGAL_CORPUS_PATH", "data/legal_corpus")
+CASOS_PATH = ROOT_DIR / os.getenv("CASOS_PATH", "data/casos")

--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -1,0 +1,22 @@
+# Variables de entorno
+
+El módulo `api/config.py` carga variables desde un archivo `.env` en la raíz del
+repositorio utilizando [python-dotenv](https://pypi.org/project/python-dotenv/).
+Las variables más relevantes son:
+
+- `OPENAI_API_KEY`: clave para la API de OpenAI.
+- `DEEPSEEK_API_KEY`: clave para la API de DeepSeek (proveedor por defecto).
+- `DEMANDAS_PATH`: ruta a la carpeta con PDFs de demandas de ejemplo
+  (predeterminado `data/demandas_ejemplo`).
+- `JURIS_PATH`: ruta a la carpeta de jurisprudencia en PDF
+  (predeterminado `data/jurisprudencia`).
+- `LEGAL_CORPUS_PATH`: ruta al corpus legal en PDF
+  (predeterminado `data/legal_corpus`).
+- `CASOS_PATH`: ruta a la carpeta con casos en PDF
+  (predeterminado `data/casos`).
+- `AV_SHEETS_CREDENTIALS`: ruta al archivo de credenciales para Google Sheets.
+- `AV_SHEETS_ID`: identificador de la hoja de cálculo de Google.
+- `AV_SHEETS_NAME`: nombre de la pestaña de la hoja (opcional).
+
+Crea un archivo `.env` y define las variables necesarias antes de ejecutar la
+aplicación.


### PR DESCRIPTION
## Summary
- add api/config.py loading .env variables with python-dotenv
- document required environment variables and PDF paths

## Testing
- `pytest` (fails: Interrupted 68 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68960a15c9a88326bf9c0ff833c253f0