### PR TITLE
Add additional LLM and PDF dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,15 @@
 fastapi
 uvicorn[standard]
 gunicorn
+pydantic
+python-dotenv
+langchain
+langchain-core
+langchain-community
+langchain-huggingface
+langchain-openai
+pdfminer.six
+pdf2image
+pytesseract
+faiss-cpu
+PyYAML


### PR DESCRIPTION
## Summary
- extend requirements with pydantic, python-dotenv, multiple langchain integrations, PDF utilities, OCR and vector indexing libraries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'keyring')*

------
https://chatgpt.com/codex/tasks/task_e_689613ebcc908326b24afd32c607eb60