### PR TITLE
Add Gradio UI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ http://localhost:8000
 ```
 
 Deberías recibir una respuesta del servicio.
+
+## Interfaz web con Gradio
+
+Para interactuar con una versión simplificada de LEXA mediante una interfaz
+gráfica, ejecuta:
+
+```bash
+PYTHONPATH=. python ui/gradio_app.py
+```
+
+Esto iniciará un servidor local de Gradio accesible en
+`http://127.0.0.1:7860` donde podrás clasificar casos y validar requisitos.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ pytesseract
 faiss-cpu
 PyYAML
 gradio
+keyring
+

--- a/ui/gradio_app.py
+++ b/ui/gradio_app.py
@@ -1,13 +1,33 @@
+"""Interfaz web simple para interactuar con LEXA mediante Gradio.
+
+El módulo `lib.demandas` requiere varias dependencias externas (incluyendo
+`keyring`).  Para que esta interfaz pueda ejecutarse incluso en entornos donde
+dichas dependencias no están instaladas, el import se realiza de forma
+opcional.  Si la importación falla, la funcionalidad de generación de demandas
+se deshabilita pero las demás herramientas continúan funcionando.
+"""
+
 import json
 import gradio as gr
 
-from lib import demandas as dem
+try:  # pragma: no cover - la importación depende de paquetes externos
+    from lib import demandas as dem
+except Exception:  # noqa: BLE001 - feedback amigable al usuario
+    dem = None
+
 from src.classifier.suggest_type import suggest_type
 from src.validators.requirements import validate_requirements
 
 
 def generar_demanda(tipo: str, caso: str) -> str:
-    """Genera una demanda del tipo indicado para el caso dado."""
+    """Genera una demanda del tipo indicado para el caso dado.
+
+    Cuando las dependencias del módulo ``lib.demandas`` no están disponibles,
+    se informa al usuario en lugar de producir un error.
+    """
+
+    if dem is None:
+        return "Función no disponible: faltan dependencias de 'lib.demandas'"
     return dem.generar_demanda_de_tipo(tipo, caso or "")
 
 


### PR DESCRIPTION
## Summary
- make gradio UI more robust when optional `lib.demandas` dependencies are missing
- document how to launch the Gradio interface
- declare missing dependency `keyring`

## Testing
- `PYTHONPATH=. python ui/gradio_app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'keyring'; ModuleNotFoundError: No module named 'pypdf'; ModuleNotFoundError: No module named 'tkcalendar'; ModuleNotFoundError: No module named 'database')*

------
https://chatgpt.com/codex/tasks/task_e_689682b9765c83268edab0bcd171e04f