### PR TITLE
Relocate database module and update imports

### DIFF
--- a/lib/database.py
+++ b/lib/database.py
@@ -4,7 +4,9 @@ from typing import List, Optional, Tuple
 from langchain.schema import Document
 
 # Default path for the SQLite database
-DB_PATH = os.path.join(os.path.dirname(__file__), "data", "app.db")
+# Adjusted to account for this module residing inside ``lib``
+# so the database is located at the project-level ``data/app.db``.
+DB_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "app.db")
 
 
 def connect() -> sqlite3.Connection:

--- a/lib/demandas.py
+++ b/lib/demandas.py
@@ -41,7 +41,7 @@ from langchain_openai import ChatOpenAI
 
 from . import tokens
 from .exact_index import build_exact_index, search_article
-import database as db
+from lib import database as db
 from src.schema_utils import (
     generate_schema_from_pdf,
     hash_for_pdf,

--- a/tests/test_email_db.py
+++ b/tests/test_email_db.py
@@ -5,7 +5,7 @@ from unittest import TestCase, mock
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import database as db
+from lib import database as db
 
 
 class EmailDbTests(TestCase):

--- a/tests/test_sync_casos_db.py
+++ b/tests/test_sync_casos_db.py
@@ -6,7 +6,7 @@ from unittest import TestCase, mock
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import database as db
+from lib import database as db
 import lib.demandas as dem
 
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -20,7 +20,7 @@ from langchain_huggingface import HuggingFaceEmbeddings
 
 from lib import tokens, demandas, costos, activation
 from lib.feedback import save_feedback
-import database as db
+from lib import database as db
 from src.classifier.suggest_type import suggest_type
 from ui.constants import (
     WINDOW_BG,


### PR DESCRIPTION
## Summary
- move database module into `lib` package and adjust default DB path
- update app, library, and tests to import database from `lib`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pypdf')*
- `pytest tests/test_email_db.py tests/test_sync_casos_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68968dca57088326a3c5789f2eb1fc2e