### PR TITLE
Fix Gradio File multiple upload argument

### DIFF
--- a/ui/gradio_app.py
+++ b/ui/gradio_app.py
@@ -151,7 +151,7 @@ with gr.Blocks() as demo:
             label="Subir jurisprudencia (PDF)",
             file_types=[".pdf"],
             interactive=True,
-            multiple=True,
+            file_count="multiple",
         )
         upload_msg = gr.Textbox(label="Resultado", lines=4)
         file_upload.upload(subir_juris, inputs=file_upload, outputs=upload_msg)


### PR DESCRIPTION
## Summary
- fix Gradio file uploader to use `file_count="multiple"`

## Testing
- `python -m py_compile ui/gradio_app.py`
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6896a4045ac883269dfd56cf29f4ead5