### PR TITLE
Handle optional demandas imports in Gradio app

### DIFF
--- a/ui/gradio_app.py
+++ b/ui/gradio_app.py
@@ -15,20 +15,20 @@ import gradio as gr
 try:  # pragma: no cover - la importación depende de paquetes externos
     from lib import demandas as dem
 
-    from lib.demandas import chat_fn, build_or_load_vectorstore
+    from lib.demandas import (
+        chat_fn,
+        build_or_load_vectorstore,
+        DemandasContext,
+        agregar_jurisprudencia_pdf,
+    )
     from langchain_community.document_loaders import PyPDFLoader
     from langchain_community.chat_message_histories import ChatMessageHistory
+    ctx = DemandasContext()
 except Exception:  # noqa: BLE001 - feedback amigable al usuario
     dem = None
     chat_fn = build_or_load_vectorstore = None
     PyPDFLoader = ChatMessageHistory = None
-
-    from lib.demandas import DemandasContext, agregar_jurisprudencia_pdf
-    ctx = DemandasContext()
-except Exception:  # noqa: BLE001 - feedback amigable al usuario
-    dem = None
-    DemandasContext = None
-    agregar_jurisprudencia_pdf = None
+    DemandasContext = agregar_jurisprudencia_pdf = None
     ctx = None
 
 


### PR DESCRIPTION
## Summary
- Simplify optional demandas imports with a single try/except and default to `None` on failure
- Guard jurisprudence upload against missing `agregar_jurisprudencia_pdf`

## Testing
- `python -m pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6896a635fca4832683847586012ce9b5