### PR TITLE
Add pypdf dependency and update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ pip install -r requirements.txt
 
 El archivo `requirements.txt` contiene todas las dependencias necesarias para ejecutar la aplicación localmente.
 
+Si ya habías instalado los requerimientos, vuelve a ejecutar `pip install -r requirements.txt` para instalar la nueva dependencia `pypdf`.
+
 ## Ejecución del servidor
 
 Inicia el servidor de desarrollo:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ faiss-cpu
 PyYAML
 gradio
 keyring
-
+pypdf


### PR DESCRIPTION
## Summary
- add pypdf to application dependencies
- document reinstalling requirements to pick up new pypdf package

## Testing
- `pip install pypdf` *(fails: Could not find a version that satisfies the requirement pypdf)*
- `pytest` *(fails: Interrupted: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6896a6375db08326a1ccb7d31167ddba