### PR TITLE
Enable Gradio sharing by default with opt-out switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ PYTHONPATH=. python ui/gradio_app.py
 
 Esto iniciará un servidor local de Gradio accesible en
 `http://127.0.0.1:7860` donde podrás clasificar casos y validar requisitos.
+
+Por defecto, la interfaz se lanza con `share=True`, lo que genera un enlace
+público de Gradio. En entornos donde se requiera evitar la exposición externa,
+puedes desactivar esta opción estableciendo la variable de entorno
+`DISABLE_GRADIO_SHARE=1` antes de ejecutar el comando anterior.

--- a/ui/gradio_app.py
+++ b/ui/gradio_app.py
@@ -157,4 +157,8 @@ with gr.Blocks() as demo:
         file_upload.upload(subir_juris, inputs=file_upload, outputs=upload_msg)
 
 if __name__ == "__main__":
-    demo.launch()
+    disable_share = os.getenv("DISABLE_GRADIO_SHARE", "").lower() in ("1", "true", "yes")
+    if disable_share:
+        demo.launch()
+    else:
+        demo.launch(share=True)


### PR DESCRIPTION
## Summary
- Launch Gradio demo with public sharing enabled and add env var switch to disable
- Document how to turn off public sharing for secure deployments

## Testing
- `pytest` *(fails: ModuleNotFoundError and other dependency-related errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6896a63834088326ac2636dff588f99c