### PR TITLE
feat(gradio): enhance demanda generation options

### DIFF
--- a/ui/gradio_app.py
+++ b/ui/gradio_app.py
@@ -20,6 +20,9 @@ try:  # pragma: no cover - la importación depende de paquetes externos
         build_or_load_vectorstore,
         DemandasContext,
         agregar_jurisprudencia_pdf,
+        listar_areas,
+        generar_demanda_desde_pdf,
+        generar_demanda_cogep_con_datos,
     )
     from langchain_community.document_loaders import PyPDFLoader
     from langchain_community.chat_message_histories import ChatMessageHistory
@@ -29,6 +32,7 @@ except Exception:  # noqa: BLE001 - feedback amigable al usuario
     chat_fn = build_or_load_vectorstore = None
     PyPDFLoader = ChatMessageHistory = None
     DemandasContext = agregar_jurisprudencia_pdf = None
+    listar_areas = generar_demanda_desde_pdf = generar_demanda_cogep_con_datos = None
     ctx = None
 
 
@@ -36,16 +40,47 @@ from src.classifier.suggest_type import suggest_type
 from src.validators.requirements import validate_requirements
 
 
-def generar_demanda(tipo: str, caso: str) -> str:
-    """Genera una demanda del tipo indicado para el caso dado.
+def get_lista_demandas():
+    return sorted(ctx.demandas_textos.keys()) if ctx else []
 
-    Cuando las dependencias del módulo ``lib.demandas`` no están disponibles,
-    se informa al usuario en lugar de producir un error.
-    """
 
-    if dem is None:
+def generar_demanda(area: str, ejemplo: str, caso: str, datos_json: str, pdf_base) -> str:
+    """Genera una demanda según las opciones proporcionadas."""
+
+    if dem is None or generar_demanda_desde_pdf is None:
         return "Función no disponible: faltan dependencias de 'lib.demandas'"
-    return dem.generar_demanda_de_tipo(tipo, caso or "")
+
+    try:
+        datos = json.loads(datos_json) if datos_json else {}
+    except Exception as exc:
+        return f"Error de formato JSON: {exc}"
+
+    carpeta_area = os.path.join(ctx.ruta_areas_root, area) if area else None
+
+    try:
+        with gr.Progress() as prog:
+            if pdf_base is not None:
+                prog(0.3, desc="Leyendo PDF base...")
+                nombre = os.path.basename(pdf_base.name)
+                carpeta = os.path.dirname(pdf_base.name)
+                texto = generar_demanda_desde_pdf(
+                    nombre, caso or "", datos=datos, ctx=ctx, carpeta=carpeta
+                )
+            elif ejemplo:
+                prog(0.3, desc="Generando desde plantilla...")
+                texto = generar_demanda_desde_pdf(
+                    ejemplo, caso or "", datos=datos, ctx=ctx, carpeta=carpeta_area
+                )
+            else:
+                prog(0.3, desc="Generando plantilla COGEP...")
+                if caso:
+                    texto = generar_demanda_cogep_con_datos(caso, ctx=ctx)
+                else:
+                    texto = dem.generar_demanda_cogep(ctx=ctx)
+            prog(1, desc="Completado")
+        return texto
+    except Exception as exc:  # noqa: BLE001
+        return f"Error al generar demanda: {exc}"
 
 
 def clasificar_caso(descripcion: str, top_n: int) -> str:
@@ -114,11 +149,20 @@ with gr.Blocks() as demo:
     gr.Markdown("# LEXA - Interfaz web con Gradio")
 
     with gr.Tab("Generar demanda"):
-        tipo_in = gr.Textbox(label="Tipo de demanda")
-        caso_in = gr.Textbox(label="Caso", lines=4)
+        area_choices = listar_areas(ctx) if listar_areas else []
+        ejemplo_choices = get_lista_demandas()
+        area_in = gr.Dropdown(label="Área", choices=area_choices)
+        ejemplo_in = gr.Dropdown(label="Modelo/Ejemplo", choices=ejemplo_choices)
+        caso_in = gr.Textbox(label="Caso", lines=2)
+        datos_in = gr.Textbox(label="Datos adicionales (JSON)", lines=4)
+        pdf_in = gr.File(label="PDF base", file_types=[".pdf"], interactive=True)
         generar_btn = gr.Button("Generar")
         resultado_out = gr.Textbox(label="Resultado", lines=10)
-        generar_btn.click(generar_demanda, inputs=[tipo_in, caso_in], outputs=resultado_out)
+        generar_btn.click(
+            generar_demanda,
+            inputs=[area_in, ejemplo_in, caso_in, datos_in, pdf_in],
+            outputs=resultado_out,
+        )
 
     with gr.Tab("Clasificar caso"):
         descripcion_in = gr.Textbox(label="Descripción del caso", lines=4)


### PR DESCRIPTION
## Summary
- allow selecting an area and demand template in Gradio's *Generar demanda* tab
- support optional JSON data and base PDF when generating demands, with progress feedback

## Testing
- `pytest -q` *(fails: No module named 'docx', No module named 'fpdf', No module named 'tkcalendar')*

------
https://chatgpt.com/codex/tasks/task_e_68973d0889ac832689d74dc929c5f82b