### PR TITLE
Remove clear and copy actions from chat page

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -695,17 +695,6 @@ class AbogadoVirtualApp:
             frame_input, text="▶️ Enviar", command=self.on_send_chat_general
         )
         btn_send.pack(side="left")
-        btn_clear = tk.Button(
-            frame_input, text="🧹 Limpiar", command=self.on_clear_chat_general
-        )
-        btn_clear.pack(side="left", padx=(5, 0))
-
-        btn_copy = tk.Button(
-            frame_input,
-            text="Copiar texto seleccionado",
-            command=self.on_copy_chat_selected,
-        )
-        btn_copy.pack(side="left", padx=(5, 0))
 
         self.lbl_chat_status = tk.Label(
             frame_chat_left,

--- a/ui/gradio_app.py
+++ b/ui/gradio_app.py
@@ -341,9 +341,6 @@ with gr.Blocks() as demo:
         input_text = gr.Textbox(label="Mensaje")
         with gr.Row():
             btn_chat = gr.Button("Enviar")
-            btn_clear = gr.Button("Limpiar")
-            btn_copy = gr.Button("Copiar")
-        copy_box = gr.Textbox(label="Texto copiado", lines=4)
         history_state = gr.State(ChatMessageHistory())
         caso_dd.change(on_case_change, inputs=caso_dd, outputs=[chatbot, history_state])
         btn_chat.click(
@@ -351,12 +348,6 @@ with gr.Blocks() as demo:
             inputs=[input_text, caso_dd, pdfs_in, chk_juris, history_state],
             outputs=[chatbot, history_state],
         )
-        btn_clear.click(
-            on_clear_chat,
-            inputs=caso_dd,
-            outputs=[chatbot, history_state, pdfs_in, copy_box],
-        )
-        btn_copy.click(on_copy_chat, inputs=history_state, outputs=copy_box)
 
     with gr.Tab("Palabras clave"):
         palabras_in = gr.Textbox(label="Ingresa palabras clave o temas")


### PR DESCRIPTION
## Summary
- Drop Limpiar and Copiar buttons from Gradio chat interface, leaving only Enviar
- Drop Limpiar and Copiar controls from Tkinter chat page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tkcalendar')*

------
https://chatgpt.com/codex/tasks/task_e_689b28ebcefc8326a4de42a696d388bf