### PR TITLE
Add grammar feedback for speaking and writing modules

### DIFF
--- a/src/feedback.py
+++ b/src/feedback.py
@@ -1,0 +1,67 @@
+"""Simple grammar feedback rules.
+
+This module provides minimal rule-based feedback for learners.  The rules are
+intentionally lightweight and focus on common B1-level errors such as misuse of
+past simple forms and prepositions.  New rules can be added easily by extending
+``RULES``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import List
+
+
+@dataclass
+class FeedbackRule:
+    """Pattern and associated message."""
+
+    pattern: re.Pattern
+    message: str
+
+
+RULES: List[FeedbackRule] = [
+    FeedbackRule(
+        re.compile(
+            r"\bdidn't\s+(?:\w+ed|went|saw|ate|was|were|had|did|made|bought|came)\b",
+            re.IGNORECASE,
+        ),
+        "Use the base form after 'didn't' (e.g., 'didn't go').",
+    ),
+    FeedbackRule(
+        re.compile(
+            r"\bin\s+(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\b",
+            re.IGNORECASE,
+        ),
+        "Use 'on' with days of the week.",
+    ),
+    FeedbackRule(
+        re.compile(r"\b(he|she|it)\s+(go|do|want|like|eat|need|have)\b", re.IGNORECASE),
+        "Add '-s' to the verb in third person singular.",
+    ),
+    FeedbackRule(
+        re.compile(r"\bhave\s+went\b", re.IGNORECASE),
+        "Use 'have gone' or 'went' instead of 'have went'.",
+    ),
+    FeedbackRule(
+        re.compile(r"\bat\s+the?\s+morning\b", re.IGNORECASE),
+        "Use 'in the morning' instead of 'at the morning'.",
+    ),
+]
+
+
+def get_feedback(text: str) -> List[str]:
+    """Return feedback messages for the given *text*.
+
+    Parameters
+    ----------
+    text:
+        User provided text to analyse.
+    """
+
+    messages: List[str] = []
+    for rule in RULES:
+        if rule.pattern.search(text):
+            messages.append(rule.message)
+    return messages

--- a/src/speaking.py
+++ b/src/speaking.py
@@ -1,0 +1,17 @@
+"""Feedback wrapper for speaking exercises."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .feedback import get_feedback
+
+
+def evaluate(transcript: str) -> List[str]:
+    """Return feedback messages for a spoken *transcript*.
+
+    This thin wrapper allows other parts of the application to reuse the
+    grammar rules defined in :mod:`src.feedback` for speaking tasks.
+    """
+
+    return get_feedback(transcript)

--- a/src/writing.py
+++ b/src/writing.py
@@ -1,0 +1,17 @@
+"""Feedback wrapper for writing exercises."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .feedback import get_feedback
+
+
+def evaluate(text: str) -> List[str]:
+    """Return feedback messages for a written *text*.
+
+    The function reuses the rule-based system defined in :mod:`src.feedback` to
+    provide grammar hints for writing tasks.
+    """
+
+    return get_feedback(text)

--- a/tests/test_grammar_feedback.py
+++ b/tests/test_grammar_feedback.py
@@ -1,0 +1,18 @@
+from src.feedback import get_feedback
+from src.speaking import evaluate as speak_eval
+from src.writing import evaluate as write_eval
+
+
+def test_past_simple_rule():
+    msgs = get_feedback("I didn't went to school")
+    assert any("didn't" in m for m in msgs)
+
+
+def test_preposition_rule():
+    msgs = write_eval("I will go in Monday")
+    assert any("days of the week" in m for m in msgs)
+
+
+def test_third_person_rule_via_speaking():
+    msgs = speak_eval("He go to work")
+    assert any("third person" in m for m in msgs)


### PR DESCRIPTION
## Summary
- implement rule-based grammar feedback engine covering past simple, preposition usage and other B1 errors
- expose feedback through new speaking and writing wrappers
- add unit tests for grammar feedback

## Testing
- `PYTHONPATH=. pytest tests/test_grammar_feedback.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'docx', 'fpdf', 'tkcalendar')*
- `pip install python-docx fpdf tkcalendar` *(fails: Could not find a version that satisfies the requirement python-docx)*

------
https://chatgpt.com/codex/tasks/task_e_689b318dc1c083268c12f2b829c59b20