### PR TITLE
Add Gradio demo with MCER B1 skill tabs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,30 @@
+"""Interfaz de práctica con pestañas para distintas habilidades MCER B1."""
+
+import gradio as gr
+
+from skills import grammar, listening, reading, speaking, vocabulary, writing
+
+MODULES = [
+    ("Listening", listening.render),
+    ("Speaking", speaking.render),
+    ("Reading", reading.render),
+    ("Writing", writing.render),
+    ("Grammar", grammar.render),
+    ("Vocabulary", vocabulary.render),
+]
+
+
+def build_demo() -> gr.Blocks:
+    """Crea la aplicación de Gradio con una pestaña por habilidad."""
+    with gr.Blocks() as demo:
+        gr.Markdown("# Práctica de inglés - Nivel B1")
+        for title, render in MODULES:
+            with gr.Tab(title):
+                render()
+    return demo
+
+
+demo = build_demo()
+
+if __name__ == "__main__":
+    demo.launch()

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Módulos de práctica por habilidad para la demo de Gradio."""

--- a/skills/grammar.py
+++ b/skills/grammar.py
@@ -1,0 +1,12 @@
+"""Ejemplo de gramática nivel MCER B1."""
+
+import gradio as gr
+
+
+def render() -> None:
+    """Renderiza el contenido de la pestaña de Grammar."""
+    gr.Markdown("### Grammar - Nivel B1")
+    gr.Markdown(
+        "Completa la frase con la forma correcta: 'I ___ (visit) London twice.'"
+    )
+    gr.Textbox(label="Respuesta")

--- a/skills/listening.py
+++ b/skills/listening.py
@@ -1,0 +1,13 @@
+"""Ejemplo sencillo de comprensión auditiva nivel MCER B1."""
+
+import gradio as gr
+
+
+def render() -> None:
+    """Renderiza el contenido de la pestaña de Listening."""
+    gr.Markdown("### Listening - Nivel B1")
+    gr.Markdown(
+        "Escucha un breve diálogo sobre planes de viaje y responde la pregunta."
+    )
+    gr.Audio(label="Audio del ejercicio", type="filepath")
+    gr.Textbox(label="¿A dónde van de vacaciones los hablantes?")

--- a/skills/reading.py
+++ b/skills/reading.py
@@ -1,0 +1,17 @@
+"""Ejemplo de comprensión lectora nivel MCER B1."""
+
+import gradio as gr
+
+TEXT = (
+    "Last year I went to the mountains with my friends. We stayed in a small cabin "
+    "and went hiking every day. On the last night, we had a big dinner in a local "
+    "restaurant."
+)
+QUESTION = "Where did they have dinner on the last night?"
+
+
+def render() -> None:
+    """Renderiza el contenido de la pestaña de Reading."""
+    gr.Markdown("### Reading - Nivel B1")
+    gr.Markdown(TEXT)
+    gr.Textbox(label=QUESTION)

--- a/skills/speaking.py
+++ b/skills/speaking.py
@@ -1,0 +1,12 @@
+"""Ejemplo de producción oral nivel MCER B1."""
+
+import gradio as gr
+
+
+def render() -> None:
+    """Renderiza el contenido de la pestaña de Speaking."""
+    gr.Markdown("### Speaking - Nivel B1")
+    gr.Markdown(
+        "Describe tu ciudad favorita durante uno o dos minutos. Usa el micrófono para grabar tu respuesta."
+    )
+    gr.Audio(label="Graba tu respuesta", sources=["microphone"])

--- a/skills/vocabulary.py
+++ b/skills/vocabulary.py
@@ -1,0 +1,10 @@
+"""Ejemplo de vocabulario nivel MCER B1."""
+
+import gradio as gr
+
+
+def render() -> None:
+    """Renderiza el contenido de la pestaña de Vocabulary."""
+    gr.Markdown("### Vocabulary - Nivel B1")
+    gr.Markdown("Escribe un sinónimo de 'journey'.")
+    gr.Textbox(label="Respuesta")

--- a/skills/writing.py
+++ b/skills/writing.py
@@ -1,0 +1,12 @@
+"""Ejemplo de expresión escrita nivel MCER B1."""
+
+import gradio as gr
+
+
+def render() -> None:
+    """Renderiza el contenido de la pestaña de Writing."""
+    gr.Markdown("### Writing - Nivel B1")
+    gr.Markdown(
+        "Escribe un correo a un amigo invitándolo a pasar un fin de semana en tu ciudad (80-100 palabras)."
+    )
+    gr.Textbox(lines=10, label="Tu correo")


### PR DESCRIPTION
## Summary
- Add top-level app.py to assemble Gradio interface for B1 practice
- Provide separate skill modules (listening, speaking, reading, writing, grammar, vocabulary) with example prompts

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tkcalendar')*
- `python app.py` *(runs locally and prints URL)*

------
https://chatgpt.com/codex/tasks/task_e_689b318ba92c8326b516d5c130ab0b71