### PR TITLE
Añade corrector gramatical con LanguageTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ Por defecto, la interfaz se lanza con `share=True`, lo que genera un enlace
 público de Gradio. En entornos donde se requiera evitar la exposición externa,
 puedes desactivar esta opción estableciendo la variable de entorno
 `DISABLE_GRADIO_SHARE=1` antes de ejecutar el comando anterior.
+
+## Errores típicos nivel B1
+
+Algunos errores frecuentes en aprendientes de nivel B1 de inglés son:
+
+- `goed` → `went`
+- `writed` → `wrote`
+- `comed` → `came` / `ate`

--- a/lib/corrector.py
+++ b/lib/corrector.py
@@ -1,0 +1,44 @@
+"""Herramientas de corrección gramatical usando LanguageTool."""
+
+try:
+    import language_tool_python
+except ImportError:  # pragma: no cover
+    language_tool_python = None
+
+_tool = None
+if language_tool_python is not None:  # pragma: no cover - lazy init
+    _tool = language_tool_python.LanguageTool("en-US")
+
+
+def corregir(texto: str):
+    """Devuelve sugerencias de corrección para ``texto``.
+
+    Cada sugerencia incluye el fragmento con error, un mensaje de
+    LanguageTool y las posibles sustituciones recomendadas.
+
+    Parameters
+    ----------
+    texto: str
+        Texto a evaluar.
+
+    Returns
+    -------
+    list[dict]
+        Lista de sugerencias con claves ``error``, ``mensaje`` y
+        ``sugerencias``.
+    """
+    if _tool is None:  # pragma: no cover
+        raise ImportError("language_tool_python no está instalado")
+
+    matches = _tool.check(texto)
+    resultados = []
+    for match in matches:
+        fragmento = texto[match.offset : match.offset + match.errorLength]
+        resultados.append(
+            {
+                "error": fragmento,
+                "mensaje": match.message,
+                "sugerencias": match.replacements,
+            }
+        )
+    return resultados

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ PyYAML
 gradio
 keyring
 pypdf
+language_tool_python

--- a/tests/test_corregir.py
+++ b/tests/test_corregir.py
@@ -1,0 +1,10 @@
+import pytest
+
+from lib.corrector import corregir
+
+language_tool_python = pytest.importorskip("language_tool_python")
+
+
+def test_corregir_sugiere_went():
+    resultados = corregir("I goed to the store yesterday.")
+    assert any("went" in sugerencia["sugerencias"] for sugerencia in resultados)


### PR DESCRIPTION
## Summary
- Agrega dependencia `language_tool_python` al proyecto
- Implementa función `corregir` que devuelve sugerencias de LanguageTool
- Documenta errores típicos nivel B1 en el README y añade prueba de ejemplo

## Testing
- `PYTHONPATH=. pytest tests/test_corregir.py -q` (skipped: falta language_tool_python)
- `pip install language_tool_python` (falla: Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689b318a1110832689e20fece99be365