### PR TITLE
Add whisper-based audio conversation utilities

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -34,3 +34,6 @@ from .activation import (
     activate_from_file,
     load_activation,
 )
+
+# utilidades de voz
+from .voice import transcribir_audio, conversar

--- a/lib/voice.py
+++ b/lib/voice.py
@@ -1,0 +1,93 @@
+"""Funciones de voz: transcripción con Whisper y respuesta con GPT-4.
+
+Este módulo proporciona utilidades para transcribir archivos de audio
+usando el modelo `whisper` de OpenAI y conversar con un LLM (por
+defecto GPT-4) usando la transcripción como entrada. Las transcripciones
+se guardan para análisis posterior.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+from pathlib import Path
+from typing import Union
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+load_dotenv()
+
+# Directorio por defecto donde se almacenarán las transcripciones
+TRANSCRIPCIONES_DIR = Path("data/transcripciones")
+
+
+def transcribir_audio(audio_path: Union[str, Path], model_name: str = "small") -> str:
+    """Transcribe el archivo de audio indicado usando `whisper`.
+
+    Parameters
+    ----------
+    audio_path: Union[str, Path]
+        Ruta al archivo de audio a transcribir.
+    model_name: str
+        Nombre del modelo de whisper a utilizar.
+
+    Returns
+    -------
+    str
+        Texto transcrito del audio.
+
+    Raises
+    ------
+    ImportError
+        Si la librería `whisper` no está instalada.
+    """
+    try:
+        import whisper  # type: ignore
+    except Exception as exc:  # pragma: no cover - error path
+        raise ImportError("whisper no está instalado") from exc
+
+    model = whisper.load_model(model_name)
+    result = model.transcribe(str(audio_path))
+    return result.get("text", "").strip()
+
+
+def conversar(
+    audio_path: Union[str, Path],
+    *,
+    model_name: str = "small",
+    llm_model: str = "gpt-4o-mini",
+    storage_dir: Union[str, Path] = TRANSCRIPCIONES_DIR,
+) -> str:
+    """Transcribe el audio y obtiene una respuesta usando GPT-4.
+
+    La transcripción se guarda en ``storage_dir`` con un nombre que
+    incluye marca de tiempo para facilitar su análisis posterior.
+
+    Parameters
+    ----------
+    audio_path: Union[str, Path]
+        Ruta del archivo de audio a procesar.
+    model_name: str, optional
+        Modelo de whisper a emplear.
+    llm_model: str, optional
+        Modelo de lenguaje a utilizar para la respuesta.
+    storage_dir: Union[str, Path], optional
+        Carpeta donde se guardarán las transcripciones.
+
+    Returns
+    -------
+    str
+        Respuesta generada por el modelo de lenguaje.
+    """
+    texto = transcribir_audio(audio_path, model_name)
+
+    storage_path = Path(storage_dir)
+    storage_path.mkdir(parents=True, exist_ok=True)
+    timestamp = _dt.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    transcript_file = storage_path / f"{Path(audio_path).stem}_{timestamp}.txt"
+    transcript_file.write_text(texto, encoding="utf-8")
+
+    llm = ChatOpenAI(model=llm_model, api_key=os.getenv("OPENAI_API_KEY"))
+    respuesta = llm.invoke(texto)
+    return getattr(respuesta, "content", str(respuesta))

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ PyYAML
 gradio
 keyring
 pypdf
+openai-whisper

--- a/tests/test_conversar.py
+++ b/tests/test_conversar.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lib import voice
+
+
+def test_conversar_transcribe_and_save(tmp_path, monkeypatch):
+    audio_file = tmp_path / "sample.wav"
+    audio_file.write_bytes(b"data")
+
+    fake_model = MagicMock()
+    fake_model.transcribe.return_value = {"text": "hola"}
+    fake_whisper = MagicMock()
+    fake_whisper.load_model.return_value = fake_model
+    monkeypatch.setitem(sys.modules, "whisper", fake_whisper)
+
+    fake_llm = MagicMock()
+    fake_llm.invoke.return_value = MagicMock(content="respuesta")
+    monkeypatch.setattr(voice, "ChatOpenAI", MagicMock(return_value=fake_llm))
+
+    resp = voice.conversar(str(audio_file), storage_dir=tmp_path)
+
+    assert resp == "respuesta"
+    saved = list(tmp_path.glob("sample_*.txt"))
+    assert len(saved) == 1
+    assert saved[0].read_text() == "hola"


### PR DESCRIPTION
## Summary
- add `transcribir_audio` and `conversar` functions using Whisper and GPT-4
- export voice helpers and declare openai-whisper dependency
- test audio conversation flow saves transcripts

## Testing
- `pytest tests/test_conversar.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docx', 'fpdf', 'tkcalendar')*


------
https://chatgpt.com/codex/tasks/task_e_689b3185f9888326abc169c4c8a1d568