### PR TITLE
Add listening tab with audio transcription

### DIFF
--- a/src/listening.py
+++ b/src/listening.py
@@ -1,0 +1,45 @@
+import os
+from typing import Tuple
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI
+except Exception:  # pragma: no cover - provide graceful fallback
+    OpenAI = None
+
+
+def escuchar(audio_path: str | None) -> Tuple[str, str]:
+    """Transcribe ``audio_path`` and answer the spoken question.
+
+    Returns a pair (transcription, response). If the OpenAI dependency is not
+    available or ``audio_path`` is invalid, an informative message is returned.
+    """
+    if OpenAI is None:
+        return "", "Función no disponible: falta la dependencia 'openai'"
+
+    if not audio_path or not os.path.exists(audio_path):
+        return "", "No se proporcionó un audio válido"
+
+    client = OpenAI()
+    try:  # pragma: no cover - network call
+        with open(audio_path, "rb") as f:
+            transcript = client.audio.transcriptions.create(
+                model="gpt-4o-mini-transcribe", file=f
+            )
+        question = getattr(transcript, "text", "").strip()
+        if not question:
+            return "", "No se pudo transcribir el audio"
+
+        resp = client.responses.create(
+            model="gpt-4o-mini",
+            input=[
+                {
+                    "role": "system",
+                    "content": "Eres un asistente que responde en español de forma concisa.",
+                },
+                {"role": "user", "content": question},
+            ],
+        )
+        answer = resp.output[0].content[0].text  # type: ignore[index]
+        return question, answer
+    except Exception as exc:  # pragma: no cover - feedback al usuario
+        return "", f"Error al procesar el audio: {exc}"

--- a/ui/gradio_app.py
+++ b/ui/gradio_app.py
@@ -64,6 +64,7 @@ except Exception:  # noqa: BLE001 - feedback amigable al usuario
 
 from src.classifier.suggest_type import suggest_type
 from src.validators.requirements import validate_requirements
+from src.listening import escuchar
 from ui.constants import CHAT_WITH_AI_OPTION
 
 tokens.init_db()
@@ -347,6 +348,25 @@ with gr.Blocks() as demo:
             responder_chat_general,
             inputs=[input_text, caso_dd, pdfs_in, chk_juris, history_state],
             outputs=[chatbot, history_state],
+        )
+
+    with gr.Tab("Listening"):
+        gr.Markdown(
+            "Graba tu pregunta en audio y LEXA la transcribirá y responderá en español."
+        )
+        audio_in = gr.Audio(source="microphone", type="filepath", label="Audio")
+        trans_out = gr.Textbox(label="Transcripción")
+        resp_out = gr.Textbox(label="Respuesta")
+        btn_listen = gr.Button("Escuchar")
+        btn_listen.click(escuchar, inputs=audio_in, outputs=[trans_out, resp_out])
+        ejemplo_box = gr.Textbox(label="Pregunta ejemplo", interactive=False)
+        gr.Examples(
+            examples=[
+                ["Describe un viaje que hayas hecho recientemente."],
+                ["¿Qué tipo de trabajo te gustaría tener en el futuro?"],
+            ],
+            inputs=ejemplo_box,
+            label="Ejemplos MCER B1",
         )
 
     with gr.Tab("Palabras clave"):


### PR DESCRIPTION
## Summary
- implement `escuchar` to transcribe audio and answer with OpenAI
- integrate a new "Listening" tab in the Gradio interface with B1 travel and work examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docx')*
- `pip install python-docx fpdf tkcalendar` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b318479648326955a63d5b05b90ff