### PR TITLE
feat: agregar constructor de cadena RAG

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -34,3 +34,5 @@ from .activation import (
     activate_from_file,
     load_activation,
 )
+
+from .rag_chain import construir_rag

--- a/lib/rag_chain.py
+++ b/lib/rag_chain.py
@@ -1,0 +1,44 @@
+"""Herramientas para construir cadenas RAG."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from langchain.chains import RetrievalQA
+from langchain_community.vectorstores import FAISS
+from langchain_core.embeddings import Embeddings
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+
+
+def construir_rag(
+    textos: Sequence[str],
+    *,
+    embeddings: Embeddings | None = None,
+    llm: ChatOpenAI | None = None,
+):
+    """Construye una cadena RAG sencilla a partir de *textos*.
+
+    Parameters
+    ----------
+    textos:
+        Lista de textos que se indexarán para la recuperación.
+    embeddings:
+        Implementación opcional de :class:`~langchain_core.embeddings.Embeddings`.
+        Si no se proporciona se usan `OpenAIEmbeddings`.
+    llm:
+        Modelo de lenguaje opcional. Por defecto se usa ``ChatOpenAI``.
+
+    Returns
+    -------
+    tuple
+        Pareja ``(cadena, retriever)`` donde ``cadena`` es una instancia de
+        :class:`~langchain.chains.RetrievalQA` lista para invocarse y
+        ``retriever`` permite realizar consultas de manera independiente.
+    """
+
+    embeddings = embeddings or OpenAIEmbeddings()
+    vectorstore = FAISS.from_texts(list(textos), embeddings)
+    retriever = vectorstore.as_retriever()
+    llm = llm or ChatOpenAI(temperature=0)
+    cadena = RetrievalQA.from_chain_type(llm=llm, retriever=retriever)
+    return cadena, retriever


### PR DESCRIPTION
## Summary
- add helper to build basic RAG chains
- export `construir_rag` from `lib`

## Testing
- `python - <<'PY'
from langchain_core.embeddings import FakeEmbeddings
from lib.rag_chain import construir_rag
textos = ["La capital de España es Madrid","La capital de Francia es París","La capital de Alemania es Berlín"]
cadena, retriever = construir_rag(textos, embeddings=FakeEmbeddings(size=32))
resultados = retriever.invoke("¿Cuál es la capital de Francia?")
for doc in resultados:
    print(doc.page_content)
PY`
- `pytest` *(fails: ModuleNotFoundError: No module named 'docx', 'fpdf', 'tkcalendar')*
- `pip install python-docx fpdf tkcalendar` *(fails: Could not find a version that satisfies the requirement python-docx)*

------
https://chatgpt.com/codex/tasks/task_e_689b3181e93c8326a2b1b394e66f1076